### PR TITLE
fix: correct graph time axis interval

### DIFF
--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -62,14 +62,14 @@ func renderGraph(data []float64, width, graphH int, clr lipgloss.Color) string {
 }
 
 // renderTimeAxis builds two rows: tick marks ('|') and timestamp labels below them.
-// numSamples is the actual number of history entries (500ms each); now is the current time.
+// numSamples is the actual number of history entries (300ms each); now is the current time.
 func renderTimeAxis(width, numSamples int, now time.Time) string {
 	if width <= 0 {
 		return "\n"
 	}
 
 	const numTicks = 10
-	displayedDuration := time.Duration(numSamples) * 500 * time.Millisecond
+	displayedDuration := time.Duration(numSamples) * 300 * time.Millisecond
 
 	tickRow := make([]byte, width)
 	for i := range tickRow {

--- a/internal/tui/graph_test.go
+++ b/internal/tui/graph_test.go
@@ -1,0 +1,17 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderTimeAxisUsesHistorySampleInterval(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	got := renderTimeAxis(100, 10, now)
+
+	rows := strings.Split(got, "\n")
+	if len(rows) != 2 || !strings.HasPrefix(rows[1], "11:59:57") {
+		t.Fatalf("left edge does not show the 3s history window; got:\n%s", got)
+	}
+}


### PR DESCRIPTION
The graph collects history every 300ms, but its time axis still counted each sample as 500ms. A full 5 minute graph was labeled as 8m20s, and the drift starts after just a few seconds. Lowkey confusing tbh.

Repro:
1. Run sudo pktz.
2. Watch any active process in the graphs pane.
3. Compare the oldest axis label with elapsed time.

This uses the real 300ms interval and adds a regression test. Timestamps line up now :)

Test: go test ./...